### PR TITLE
Rename logshipper to logs-to-vector.

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -12,3 +12,5 @@ jobs:
     name: Flowzone
     uses: product-os/flowzone/.github/workflows/flowzone.yml@master
     secrets: inherit
+    with:
+      balena_slugs: 'balenalabs/logs-to-vector-aarch64,balenalabs/logs-to-vector-amd64,balenalabs/logs-to-vector-armv7hf'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# logshipper
+# logs-to-vector
 
 A log collection agent that ships logs from the balena engine to a downstream
 log aggregator.  It uses [Vector][vector] as an agent to collect the logs from
 journald, add labels to the logs, and send the logs to a log aggregator.
 
-Important: Starting v1.0.0, logshipper now uses Vector API v2 which is incompatible
+Important: Starting v1.0.0, logs-to-vector now uses Vector API v2 which is incompatible
 with Vector API v1.  If you are using a Vector API v1 endpoint, please use
-logshipper v0.2.1 instead.
+logs-to-vector v0.2.1 instead.
 
 The agent currently ships logs to the following log aggregators:
 - [Vector][vector]
@@ -19,15 +19,15 @@ To use this image, create a service in your `docker-compose.yml` as shown below:
 version: "2.1"
 
 volumes:
-  logshipper: {}
+  logs-to-vector: {}
 
-logshipper:
-    image: bh.cr/balenablocks/logshipper
+logs-to-vector:
+    image: bh.cr/balenablocks/logs-to-vector
     labels:
       io.balena.features.journal-logs: '1'
     restart: unless_stopped
     volumes:
-      - logshipper:/var/lib/logshipper
+      - logs-to-vector:/var/lib/logs-to-vector
 ```
 
 You can also set your docker-compose.yml to build from a Dockerfile.template file. 
@@ -38,21 +38,21 @@ You may add your own Vector sinks that takes `balena` as input.
 version: "2.1"
 
 volumes:
-  logshipper: {}
+  logs-to-vector: {}
 
 services:
-  logshipper:
+  logs-to-vector:
     build: ./
     labels:
       io.balena.features.journal-logs: '1'
     restart: unless_stopped
     volumes:
-      - logshipper:/var/lib/logshipper
+      - logs-to-vector:/var/lib/logs-to-vector
 ```
 
 *Dockerfile.template*
 ```
-FROM bh.cr/balenablocks/logshipper
+FROM bh.cr/balenablocks/logs-to-vector
 
 COPY sink.yaml /etc/vector
 ```
@@ -69,11 +69,11 @@ sinks:
 
 ## Customisation
 
-`bh.cr/balenablocks/logshipper` can be configured via the following variables:
+`bh.cr/balenablocks/logs-to-vector` can be configured via the following variables:
 
 | Environment Variable            | Default  | Description                                                |
 | ------------------------------- | -------- | ---------------------------------------------------------- |
-| `DISABLE`                       | `false`  | Disables the logshipper service                            |
+| `DISABLE`                       | `false`  | Disables the logs-to-vector service                            |
 | `VECTOR_BUFFER_MAX_EVENTS`      | `1000`   | The maximum number of events allowed in the buffer         |
 | `VECTOR_BUFFER_MAX_SIZE`        | `268435488` | The maximum size of the buffer on the disk              |
 | `VECTOR_BUFFER_TYPE`            | `memory` | The type of buffer to use                                  |

--- a/balena.yml
+++ b/balena.yml
@@ -1,22 +1,29 @@
-name: log-shipper
+name: logs-to-vector
 type: sw.block
 description: >-
   A log collection agent that ships logs from the balena engine to a downstream
-  log aggregator.  It uses Vector as an agent to collect the logs from
-  journald, add labels to the logs, and send the logs to a log aggregator.
+  Vector endpoint.  It uses Vector (https://vector.dev) as an agent to collect
+  the logs from either journald of the Kubernetes API depending on the environment
+  that it is running in. It then adds labels to the logs then send the logs to a
+  receiving Vector endpoint.
 assets:
   repository:
     type: blob.asset
     data:
-      url: 'https://github.com/balenablocks/logshipper'
+      url: 'https://github.com/balena-labs-projects/logs-to-vector'
 data:
   defaultDeviceType: genericx86-64-ext
   supportedDeviceTypes:
+    - fincm3
     - generic
     - genericx86-64-ext
     - intel-nuc
     - odyssey-x86
     - qemux86-64
+    - raspberry-pi
+    - raspberry-pi2
+    - raspberrypi3
+    - raspberrypi4-64
     - surface-go
     - surface-pro-6
     - up-board

--- a/start.sh
+++ b/start.sh
@@ -62,7 +62,7 @@ function start_vector() {
 
 
 if [[ "$DISABLED" =~ true|True|TRUE|yes|Yes|YES|on|On|ON|1 ]]; then
-	echo 'Logshipper has been disabled. This service is now idle.'
+	echo 'logs-to-vector has been disabled. This service is now idle.'
 	sleep infinity
 else
 	BALENA_FLEET_NAME=${BALENA_APP_NAME}

--- a/vector.yaml
+++ b/vector.yaml
@@ -7,7 +7,7 @@ api:
   address: "0.0.0.0:8686"
 
 # Data dir is location controlled at the `DaemonSet`.
-data_dir: /var/lib/logshipper
+data_dir: /var/lib/logs-to-vector
 
 log_schema:
   host_key: host


### PR DESCRIPTION
Also updates Github Action to automate deployment
to balenaCloud.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>