### PR TITLE
Accepts multi-line string for certificates env vars.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+

--- a/start.sh
+++ b/start.sh
@@ -4,22 +4,28 @@
 set -ae
 
 function prepare_source_balena() {
-    if [ -n "$BALENA_DEVICE_UUID" ]
-    then
+    if [ -n "$BALENA_DEVICE_UUID" ]; then
         mkdir -p sources transforms
-        envsubst < templates/sources/journald.yaml.template > sources/journald.yaml
-        envsubst < templates/transforms/source-balena.yaml.template > transforms/source-balena.yaml
+        envsubst <templates/sources/journald.yaml.template >sources/journald.yaml
+        envsubst <templates/transforms/source-balena.yaml.template >transforms/source-balena.yaml
     fi
 }
 
 function prepare_source_kubernetes() {
-    if [ -n "$KUBERNETES_SERVICE_HOST" ]
-    then
+    if [ -n "$KUBERNETES_SERVICE_HOST" ]; then
         VECTOR_BUFFER_TYPE=${VECTOR_BUFFER_TYPE:-disk}
         VECTOR_BUFFER_WHEN_FULL=${VECTOR_BUFFER_WHEN_FULL:-block}
         mkdir -p sources
-        envsubst < templates/sources/source-kubernetes.yaml.template > sources/source-kubernetes.yaml
+        envsubst <templates/sources/source-kubernetes.yaml.template >sources/source-kubernetes.yaml
     fi
+}
+
+function write_to_file() {
+    VARIABLE=$1
+    FILE_PATH=$2
+    # Accept both base64 and multi-line strings as input values
+    # for env vars to be written as files
+    echo "${VARIABLE}" | base64 -d >"${FILE_PATH}" 2>/dev/null || echo "${VARIABLE}" >"${FILE_PATH}"
 }
 
 function prepare_sink_vector() {
@@ -27,7 +33,7 @@ function prepare_sink_vector() {
 
     # Set default values here
     VECTOR_ACKNOWLEDGEMENTS_ENABLED=${VECTOR_ACKNOWLEDGEMENTS_ENABLED:-true}
-    VECTOR_BUFFER_TYPE=${VECTOR_BUFFER_TYPE:-memory} 
+    VECTOR_BUFFER_TYPE=${VECTOR_BUFFER_TYPE:-memory}
     VECTOR_BUFFER_WHEN_FULL=${VECTOR_BUFFER_WHEN_FULL:-drop_newest}
     # Temporarily handle old environment variable names
     test -n "$VECTOR_BUFFER_MAX_EVENTS" && VECTOR_BUFFER_MEMORY_MAX_EVENTS=${VECTOR_BUFFER_MAX_EVENTS}
@@ -39,42 +45,41 @@ function prepare_sink_vector() {
 
     # Prepare the configuration file
     if [ -n "${VECTOR_ENDPOINT}" ]; then
-        envsubst < templates/sinks/sink-vector.yaml.template > sinks/sink-vector.yaml
+        envsubst <templates/sinks/sink-vector.yaml.template >sinks/sink-vector.yaml
         if [ -n "${VECTOR_TLS_CA_FILE}" ]; then
             VECTOR_TLS_ENABLED=true
-			VECTOR_TLS_VERIFY_CERTIFICATE=${VECTOR_TLS_VERIFY_CERTIFICATE:-true}
-			VECTOR_TLS_VERIFY_HOSTNAME=${VECTOR_TLS_VERIFY_HOSTNAME:-true}
-            envsubst < templates/sinks/sink-vector.yaml.template > sinks/sink-vector.yaml
-            echo "${VECTOR_TLS_CA_FILE}" | base64 -d > "${CERTIFICATES_DIR}/ca.pem"
+            VECTOR_TLS_VERIFY_CERTIFICATE=${VECTOR_TLS_VERIFY_CERTIFICATE:-true}
+            VECTOR_TLS_VERIFY_HOSTNAME=${VECTOR_TLS_VERIFY_HOSTNAME:-true}
+            envsubst <templates/sinks/sink-vector.yaml.template >sinks/sink-vector.yaml
+            write_to_file "${VECTOR_TLS_CA_FILE}" "${CERTIFICATES_DIR}/ca.pem"
             sed -i 's|#ca_file:|ca_file:|g' sinks/sink-vector.yaml
             if [ -n "${VECTOR_TLS_CRT_FILE}" ] && [ -n "${VECTOR_TLS_KEY_FILE}" ]; then
-                echo "${VECTOR_TLS_CRT_FILE}" | base64 -d > "${CERTIFICATES_DIR}/client.pem"
-                echo "${VECTOR_TLS_KEY_FILE}" | base64 -d > "${CERTIFICATES_DIR}/client-key.pem"
+                write_to_file "${VECTOR_TLS_CRT_FILE}" "${CERTIFICATES_DIR}/client.pem"
+                write_to_file "${VECTOR_TLS_KEY_FILE}" "${CERTIFICATES_DIR}/client-key.pem"
                 sed -i 's|#crt_file:|crt_file:|g' sinks/sink-vector.yaml
                 sed -i 's|#key_file:|key_file:|g' sinks/sink-vector.yaml
-				sed -i 's|#verify_certificate:|verify_certificate:|g' sinks/sink-vector.yaml
-				sed -i 's|#verify_hostname:|verify_hostname:|g' sinks/sink-vector.yaml
+                sed -i 's|#verify_certificate:|verify_certificate:|g' sinks/sink-vector.yaml
+                sed -i 's|#verify_hostname:|verify_hostname:|g' sinks/sink-vector.yaml
             fi
         else
             VECTOR_TLS_ENABLED=false
-            envsubst < templates/sinks/sink-vector.yaml.template > sinks/sink-vector.yaml
+            envsubst <templates/sinks/sink-vector.yaml.template >sinks/sink-vector.yaml
         fi
 
         if [[ "${VECTOR_BUFFER_TYPE}" == 'disk' ]]; then
-                sed -i 's|#max_size:|max_size:|g' sinks/sink-vector.yaml
+            sed -i 's|#max_size:|max_size:|g' sinks/sink-vector.yaml
         else
-                sed -i 's|#max_events:|max_events:|g' sinks/sink-vector.yaml
+            sed -i 's|#max_events:|max_events:|g' sinks/sink-vector.yaml
         fi
     fi
 }
 
 function start_vector() {
     # https://vector.dev/docs/administration/validating/
-    find /etc/vector -name "*.y*ml" -exec cat {} \; 
-    vector validate --config-dir /etc/vector \
-    && vector --config-dir /etc/vector
+    find /etc/vector -name "*.y*ml" -exec cat {} \;
+    vector validate --config-dir /etc/vector &&
+        vector --config-dir /etc/vector
 }
-
 
 if [[ "$DISABLED" =~ true|True|TRUE|yes|Yes|YES|on|On|ON|1 ]]; then
     echo 'logs-to-vector has been disabled. This service is now idle.'


### PR DESCRIPTION
Certificates used to be only accepted in base64 format. This update allows users to set certificates as multi-line strings in environment variables. This also makes it easy to mount certificates in kubernetes secrets as environment variables for logs-to-vector.

Change-type: minor